### PR TITLE
DDCE-6951- For maintain-tax-liability-frontend service, dependencies are updated

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,8 +2,8 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.13.0"
-  val mongoVersion = "2.6.0"
+  val bootstrapVersion = "9.18.0"
+  val mongoVersion = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-30" % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.7")
+addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.8")
 addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("com.github.sbt"       % "sbt-gzip"              % "2.0.0")


### PR DESCRIPTION
DDCE-6951- For maintain-tax-liability-frontend service, dependencies BootstrapVersion, MongoVersion & sbt-plugin version updated to 9.18.0 , 2.7.0 & 3.0.8 respectively.
<img width="959" height="561" alt="DDCE-6951 - Execution Result" src="https://github.com/user-attachments/assets/d0786d5b-9e71-4863-9eca-f250f322391d" />
